### PR TITLE
PE-4 Update version in package.json

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -129,6 +129,11 @@ jobs:
       with:
         ref: ${{ inputs.tag }}
 
+    - name: Update version in package.json with tag
+      run: >
+        jq -r '.version = "${{ inputs.tag }}"' package.json > package-tag-version.json
+        && mv package-tag-version.json package.json
+
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
       with:


### PR DESCRIPTION
When the Lambda ZIP files are uploaded to S3, their key includes the fully qualified tag, not just the semver. Since the Terraform configuration extracts the version from the package.json file, we need to update this to be the fully qualified tag as well.