### PR TITLE
PE-4 Move NPM_AUTH_TOKEN variable

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -51,6 +51,8 @@ jobs:
   generate-function-list:
     name: Generate list of Lambda functions
     runs-on: ubuntu-latest
+    env:
+      NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
     steps:
 
     - name: Checkout code
@@ -89,8 +91,6 @@ jobs:
 
     - name: Install dependencies
       run: yarn
-      env:
-        NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
     - name: Build Lambda function
       run: >
@@ -100,8 +100,6 @@ jobs:
     - name: Build Lambda function zip file
       run: zip -r -q ${{ env.ZIP_FILE_NAME}} ${{ matrix.function }}.js
       working-directory: dist
-      env:
-        NPM_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
     - name: Upload Lambda function asset to release
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
The `NPM_AUTH_TOKEN` variable was added to the wrong step. This gives us a chance to move this to job scope so that is applied applied to all steps and we don't have to duplicate for each step that need it.