### PR TITLE
PE-4 Add function-domain input

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -7,6 +7,10 @@ on:
         required: true
         description: 'AWS environment'
         type: string
+      function-domain:
+        required: true
+        description: 'The domain of the Lambda functions that will be used in the S3 bucket key (e.g., "CustomerService" or "CiCdAutomation")'
+        type: string
       tag:
         required: true
         description: 'The tag of the release to be deployed'
@@ -116,7 +120,7 @@ jobs:
     - name: Upload lambda functions to S3
       run: >
         aws s3 cp ${{ env.ARTIFACT_NAME }}
-        s3://${{ env.S3_BUCKET }}/CustomerService/${{ matrix.function }}/${{ env.ARTIFACT_NAME }}
+        s3://${{ env.S3_BUCKET }}/${{ inputs.function-domain }}/${{ matrix.function }}/${{ env.ARTIFACT_NAME }}
 
   apply-terraform-changes:
     name: Apply Terraform changes


### PR DESCRIPTION
Part of the S3 key for a Lambda function's code is the domain to which that function belongs (usually a service name like "CustomerService"). There is not an obvious way to "derive" the value, so we are adding an another workflow input so that consuming workflows can pass this value in.

See our ADR for more details:

https://github.com/invitation-homes/technology-decisions/blob/main/0064-lambda-naming-conventions.md
