### PR TITLE
PE-18 Add support for source maps

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -8,6 +8,11 @@ on:
         description: Any external libraries that should be considered by esbuild
         required: false
         default: ""
+      use-source-map:
+        type: boolean
+        description: Whether to include source maps in the bundle
+        required: false
+        default: false
 
 jobs:
   create-github-release:
@@ -91,10 +96,19 @@ jobs:
     - name: Install dependencies
       run: yarn
 
-    - name: Build Lambda function
+    - name: Enable source map option for esbuild
+      run: echo "source_map_option=yellow" >> $GITHUB_ENV
+      if: inputs.use-source-map
+
+    - name: Configure external option for esbuild
+      run: echo "external_option=--external:${{ inputs.esbuild-external }}" >> $GITHUB_ENV
+      if: ${{ inputs.esbuild-external != "" }}
+
+    - name: Bundle Lambda function code
       run: >
-        yarn esbuild --bundle --outfile=dist/${{ matrix.function }}.js --platform=node 
-        "--external:${{ inputs.esbuild-external }}" ./src/functions/${{ matrix.function }}
+        yarn esbuild --bundle --outfile=dist/${{ matrix.function }}.js --platform=node
+        ${{ env.external_option }} ${{ env.source_map_option }}
+        ./src/functions/${{ matrix.function }}
 
     - name: Build Lambda function zip file
       run: zip -r -q ${{ env.ZIP_FILE_NAME}} ${{ matrix.function }}.js

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
     secrets: inherit
 ```
 
-This workflow accepts an optional `esbuild-external` input variable. This is passed to the esbuild process as the value for the `external` CLI option. See the [esbuild documentation](https://esbuild.github.io/api/#external) for more details.
+This workflow accepts two optional input variables. The first is `esbuild-external`, which is passed to the esbuild process as the value for the `external` CLI option. See the [esbuild documentation](https://esbuild.github.io/api/#external) for more details.
 
 ```yaml
 jobs:
@@ -41,6 +41,17 @@ jobs:
     uses: invitation-homes/typescript-lambda-workflows/.github/workflows/build-release-candidate.yml@v1
     with:
       esbuild-external: pg-native
+```
+
+The second input variable is `use-source-map`. The default value is `false`. When this is set to `true`, the Lambda function's code will be bundled with source maps. To take advantage of this, Lambda functions must also have the environment variable `NODE_OPTIONS=--enable-source-maps`. See the [esbuild documentation](https://esbuild.github.io/api/#sourcemap) and [this blog post](https://serverless.pub/aws-lambda-node-sourcemaps/) for more details.
+
+```yaml
+jobs:
+  build-release-candidate:
+    name: Build release candidate
+    uses: invitation-homes/typescript-lambda-workflows/.github/workflows/build-release-candidate.yml@v1
+    with:
+      use-source-map: true
 ```
 
 ## Deploy Application Workflow


### PR DESCRIPTION
Add optional support for source maps when bundling Lambda function code so that we can get meaningful stack traces. This change also introduces the usage of `GITHUB_ENV` in favor our `set-output`, which has been [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).